### PR TITLE
Acceptance test fix

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,7 +10,7 @@ build: fmtcheck
 test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=32s -parallel=4
+		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,7 +10,7 @@ build: fmtcheck
 test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
+		xargs -t -n4 go test $(TESTARGS) -timeout=32s -parallel=4
 
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ make build
 
 Using the provider
 ----------------------
-## Fill in for each provider
+See the [ProfitBricks Provider documentation](https://www.terraform.io/docs/providers/profitbricks/index.html) to get started using the ProfitBricks provider.
 
 Developing the Provider
 ---------------------------

--- a/profitbricks/data_source_datacenter_test.go
+++ b/profitbricks/data_source_datacenter_test.go
@@ -17,7 +17,6 @@ func TestAccDataSourceDatacenter_matching(t *testing.T) {
 				Config: testAccDataSourceProfitBricksDataCenter_matching,
 			},
 			{
-
 				Config: testAccDataSourceProfitBricksDataCenter_matchingWithDataSource,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.profitbricks_datacenter.foobar", "name", "test_name"),

--- a/profitbricks/data_source_image_test.go
+++ b/profitbricks/data_source_image_test.go
@@ -1,14 +1,13 @@
 package profitbricks
 
 import (
-	"fmt"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
-	"strings"
+	"regexp"
 	"testing"
 )
 
 func TestAccDataSourceImage_basic(t *testing.T) {
+	r, _ := regexp.Compile("Ubuntu-16.04")
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -20,28 +19,13 @@ func TestAccDataSourceImage_basic(t *testing.T) {
 				Config: testAccDataSourceProfitBricksImage_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.profitbricks_image.img", "location", "us/las"),
-					testAccCheckProfitBricksImageAttributes("data.profitbricks_image.img", "Ubuntu-16.04"),
+					resource.TestMatchResourceAttr("data.profitbricks_image.img", "name", r),
 					resource.TestCheckResourceAttr("data.profitbricks_image.img", "type", "HDD"),
 				),
 			},
 		},
 	})
 
-}
-
-func testAccCheckProfitBricksImageAttributes(n string, name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("testAccCheckProfitBricksImageAttributes: Not found: %s", n)
-		}
-
-		if !strings.Contains(rs.Primary.Attributes["name"], name) {
-			return fmt.Errorf("Bad name: %s", rs.Primary.Attributes["name"])
-		}
-
-		return nil
-	}
 }
 
 const testAccDataSourceProfitBricksImage_basic = `

--- a/profitbricks/data_source_image_test.go
+++ b/profitbricks/data_source_image_test.go
@@ -1,7 +1,10 @@
 package profitbricks
 
 import (
+	"fmt"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"strings"
 	"testing"
 )
 
@@ -17,13 +20,28 @@ func TestAccDataSourceImage_basic(t *testing.T) {
 				Config: testAccDataSourceProfitBricksImage_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.profitbricks_image.img", "location", "us/las"),
-					resource.TestCheckResourceAttr("data.profitbricks_image.img", "name", "Ubuntu-16.04-LTS-server-2017-05-01"),
+					testAccCheckProfitBricksImageAttributes("data.profitbricks_image.img", "Ubuntu-16.04"),
 					resource.TestCheckResourceAttr("data.profitbricks_image.img", "type", "HDD"),
 				),
 			},
 		},
 	})
 
+}
+
+func testAccCheckProfitBricksImageAttributes(n string, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("testAccCheckProfitBricksImageAttributes: Not found: %s", n)
+		}
+
+		if !strings.Contains(rs.Primary.Attributes["name"], name) {
+			return fmt.Errorf("Bad name: %s", rs.Primary.Attributes["name"])
+		}
+
+		return nil
+	}
 }
 
 const testAccDataSourceProfitBricksImage_basic = `
@@ -33,4 +51,4 @@ const testAccDataSourceProfitBricksImage_basic = `
 	  version = "16"
 	  location = "us/las"
 	}
-	`
+`

--- a/profitbricks/resource_profitbricks_datacenter.go
+++ b/profitbricks/resource_profitbricks_datacenter.go
@@ -97,7 +97,11 @@ func resourceProfitBricksDatacenterUpdate(d *schema.ResourceData, meta interface
 	}
 
 	resp := profitbricks.PatchDatacenter(d.Id(), obj)
-	waitTillProvisioned(meta, resp.Headers.Get("Location"))
+	err := waitTillProvisioned(meta, resp.Headers.Get("Location"))
+	if err != nil {
+		return err
+	}
+
 	return resourceProfitBricksDatacenterRead(d, meta)
 }
 

--- a/profitbricks/resource_profitbricks_datacenter_test.go
+++ b/profitbricks/resource_profitbricks_datacenter_test.go
@@ -21,14 +21,14 @@ func TestAccProfitBricksDataCenter_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDProfitBricksDatacenterDestroyCheck,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckProfitBricksDatacenterConfig_basic, dc_name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfitBricksDatacenterExists("profitbricks_datacenter.foobar", &datacenter),
 					resource.TestCheckResourceAttr("profitbricks_datacenter.foobar", "name", dc_name),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckProfitBricksDatacenterConfig_update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfitBricksDatacenterExists("profitbricks_datacenter.foobar", &datacenter),
@@ -53,20 +53,6 @@ func testAccCheckDProfitBricksDatacenterDestroyCheck(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckProfitBricksDatacenterAttributes(n string, name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-		if rs.Primary.Attributes["name"] != name {
-			return fmt.Errorf("Bad name: expected %s : found %s ", name, rs.Primary.Attributes["name"])
-		}
-
-		return nil
-	}
 }
 
 func testAccCheckProfitBricksDatacenterExists(n string, datacenter *profitbricks.Datacenter) resource.TestCheckFunc {

--- a/profitbricks/resource_profitbricks_datacenter_test.go
+++ b/profitbricks/resource_profitbricks_datacenter_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/profitbricks/profitbricks-sdk-go"
-	"time"
 )
 
 func TestAccProfitBricksDataCenter_Basic(t *testing.T) {
@@ -56,7 +55,6 @@ func testAccCheckDProfitBricksDatacenterDestroyCheck(s *terraform.State) error {
 }
 
 func testAccCheckProfitBricksDatacenterExists(n string, datacenter *profitbricks.Datacenter) resource.TestCheckFunc {
-	time.Sleep(15 * time.Second)
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 

--- a/profitbricks/resource_profitbricks_datacenter_test.go
+++ b/profitbricks/resource_profitbricks_datacenter_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/profitbricks/profitbricks-sdk-go"
+	"time"
 )
 
 func TestAccProfitBricksDataCenter_Basic(t *testing.T) {
@@ -24,7 +25,6 @@ func TestAccProfitBricksDataCenter_Basic(t *testing.T) {
 				Config: fmt.Sprintf(testAccCheckProfitBricksDatacenterConfig_basic, dc_name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfitBricksDatacenterExists("profitbricks_datacenter.foobar", &datacenter),
-					testAccCheckProfitBricksDatacenterAttributes("profitbricks_datacenter.foobar", dc_name),
 					resource.TestCheckResourceAttr("profitbricks_datacenter.foobar", "name", dc_name),
 				),
 			},
@@ -32,7 +32,6 @@ func TestAccProfitBricksDataCenter_Basic(t *testing.T) {
 				Config: testAccCheckProfitBricksDatacenterConfig_update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfitBricksDatacenterExists("profitbricks_datacenter.foobar", &datacenter),
-					testAccCheckProfitBricksDatacenterAttributes("profitbricks_datacenter.foobar", "updated"),
 					resource.TestCheckResourceAttr("profitbricks_datacenter.foobar", "name", "updated"),
 				),
 			},
@@ -71,6 +70,7 @@ func testAccCheckProfitBricksDatacenterAttributes(n string, name string) resourc
 }
 
 func testAccCheckProfitBricksDatacenterExists(n string, datacenter *profitbricks.Datacenter) resource.TestCheckFunc {
+	time.Sleep(15 * time.Second)
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 

--- a/profitbricks/resource_profitbricks_firewall_test.go
+++ b/profitbricks/resource_profitbricks_firewall_test.go
@@ -20,7 +20,7 @@ func TestAccProfitBricksFirewall_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDProfitBricksFirewallDestroyCheck,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckProfitbricksFirewallConfig_basic, firewallName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfitBricksFirewallExists("profitbricks_firewall.webserver_http", &firewall),
@@ -28,7 +28,7 @@ func TestAccProfitBricksFirewall_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("profitbricks_firewall.webserver_http", "name", firewallName),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckProfitbricksFirewallConfig_update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfitBricksFirewallAttributes("profitbricks_firewall.webserver_http", "updated"),

--- a/profitbricks/resource_profitbricks_ipblock_test.go
+++ b/profitbricks/resource_profitbricks_ipblock_test.go
@@ -20,7 +20,7 @@ func TestAccProfitBricksIPBlock_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDProfitBricksIPBlockDestroyCheck,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckProfitbricksIPBlockConfig_basic, location),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfitBricksIPBlockExists("profitbricks_ipblock.webserver_ip", &ipblock),

--- a/profitbricks/resource_profitbricks_lan_test.go
+++ b/profitbricks/resource_profitbricks_lan_test.go
@@ -20,7 +20,7 @@ func TestAccProfitBricksLan_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDProfitBricksLanDestroyCheck,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckProfitbricksLanConfig_basic, lanName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfitBricksLanExists("profitbricks_lan.webserver_lan", &lan),
@@ -28,7 +28,7 @@ func TestAccProfitBricksLan_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("profitbricks_lan.webserver_lan", "name", lanName),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckProfitbricksLanConfig_update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfitBricksLanAttributes("profitbricks_lan.webserver_lan", "updated"),

--- a/profitbricks/resource_profitbricks_loadbalancer_test.go
+++ b/profitbricks/resource_profitbricks_loadbalancer_test.go
@@ -20,7 +20,7 @@ func TestAccProfitBricksLoadbalancer_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDProfitBricksLoadbalancerDestroyCheck,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckProfitbricksLoadbalancerConfig_basic, lbName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfitBricksLoadbalancerExists("profitbricks_loadbalancer.example", &loadbalancer),
@@ -28,7 +28,7 @@ func TestAccProfitBricksLoadbalancer_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("profitbricks_loadbalancer.example", "name", lbName),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckProfitbricksLoadbalancerConfig_update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfitBricksLoadbalancerAttributes("profitbricks_loadbalancer.example", "updated"),

--- a/profitbricks/resource_profitbricks_nic.go
+++ b/profitbricks/resource_profitbricks_nic.go
@@ -156,10 +156,12 @@ func resourceProfitBricksNicUpdate(d *schema.ResourceData, meta interface{}) err
 	if nic.StatusCode > 299 {
 		return fmt.Errorf("Error occured while updating a nic: %s", nic.Response)
 	}
+
 	err := waitTillProvisioned(meta, nic.Headers.Get("Location"))
 	if err != nil {
 		return err
 	}
+
 	return resourceProfitBricksNicRead(d, meta)
 }
 

--- a/profitbricks/resource_profitbricks_nic_test.go
+++ b/profitbricks/resource_profitbricks_nic_test.go
@@ -20,7 +20,7 @@ func TestAccProfitBricksNic_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDProfitBricksNicDestroyCheck,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckProfitbricksNicConfig_basic, volumeName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfitBricksNICExists("profitbricks_nic.database_nic", &nic),
@@ -28,7 +28,7 @@ func TestAccProfitBricksNic_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("profitbricks_nic.database_nic", "name", volumeName),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckProfitbricksNicConfig_update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfitBricksNicAttributes("profitbricks_nic.database_nic", "updated"),

--- a/profitbricks/resource_profitbricks_nic_test.go
+++ b/profitbricks/resource_profitbricks_nic_test.go
@@ -133,7 +133,7 @@ resource "profitbricks_nic" "database_nic" {
   datacenter_id = "${profitbricks_datacenter.foobar.id}"
   server_id = "${profitbricks_server.webserver.id}"
   lan = 2
-  dhcp = true
+  dhcp = false
   firewall_active = true
   name = "%s"
 }`
@@ -175,7 +175,7 @@ resource "profitbricks_nic" "database_nic" {
   datacenter_id = "${profitbricks_datacenter.foobar.id}"
   server_id = "${profitbricks_server.webserver.id}"
   lan = 2
-  dhcp = true
+  dhcp = false
   firewall_active = true
   name = "updated"
 }

--- a/profitbricks/resource_profitbricks_server.go
+++ b/profitbricks/resource_profitbricks_server.go
@@ -530,6 +530,16 @@ func resourceProfitBricksServerUpdate(d *schema.ResourceData, meta interface{}) 
 	}
 	server := profitbricks.PatchServer(dcId, d.Id(), request)
 
+	if server.StatusCode > 299 {
+		return fmt.Errorf(
+			"Error patching Server (%s)", server.Response)
+	}
+
+	err := waitTillProvisioned(meta, server.Headers.Get("Location"))
+	if err != nil {
+		return err
+	}
+
 	//Volume stuff
 	if d.HasChange("volume") {
 		volume := server.Entities.Volumes.Items[0]
@@ -614,10 +624,6 @@ func resourceProfitBricksServerUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
-	if server.StatusCode > 299 {
-		return fmt.Errorf(
-			"Error patching server (%s) (%s)", d.Id(), server.Response)
-	}
 	return resourceProfitBricksServerRead(d, meta)
 }
 

--- a/profitbricks/resource_profitbricks_server_test.go
+++ b/profitbricks/resource_profitbricks_server_test.go
@@ -20,7 +20,7 @@ func TestAccProfitBricksServer_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDProfitBricksServerDestroyCheck,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckProfitbricksServerConfig_basic, serverName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfitBricksServerExists("profitbricks_server.webserver", &server),
@@ -28,7 +28,7 @@ func TestAccProfitBricksServer_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("profitbricks_server.webserver", "name", serverName),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckProfitbricksServerConfig_update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfitBricksServerAttributes("profitbricks_server.webserver", "updated"),

--- a/profitbricks/resource_profitbricks_server_test.go
+++ b/profitbricks/resource_profitbricks_server_test.go
@@ -157,7 +157,7 @@ resource "profitbricks_server" "webserver" {
   volume {
     name = "system"
     size = 5
-    disk_type = "SSD"
+    disk_type = "HDD"
     image_name ="ubuntu-16.04"
     image_password = "K3tTj8G14a3EgKyNeeiY"
 }

--- a/profitbricks/resource_profitbricks_volume.go
+++ b/profitbricks/resource_profitbricks_volume.go
@@ -167,9 +167,6 @@ func resourceProfitBricksVolumeCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceProfitBricksVolumeRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*Config)
-	profitbricks.SetAuth(config.Username, config.Password)
-
 	dcId := d.Get("datacenter_id").(string)
 
 	volume := profitbricks.GetVolume(dcId, d.Id())
@@ -192,6 +189,7 @@ func resourceProfitBricksVolumeRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("size", volume.Properties.Size)
 	d.Set("bus", volume.Properties.Bus)
 	d.Set("image_name", volume.Properties.Image)
+	d.Set("availability_zone", volume.Properties.AvailabilityZone)
 
 	return nil
 }
@@ -230,18 +228,8 @@ func resourceProfitBricksVolumeUpdate(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("An error occured while updating a volume ID %s %s", d.Id(), volume.Response)
 
 	}
-	err = resourceProfitBricksVolumeRead(d, meta)
-	if err != nil {
-		return err
-	}
-	d.SetId(d.Get("server_id").(string))
-	err = resourceProfitBricksServerRead(d, meta)
-	if err != nil {
-		return err
-	}
 
-	d.SetId(volume.Id)
-	return nil
+	return resourceProfitBricksVolumeRead(d, meta)
 }
 
 func resourceProfitBricksVolumeDelete(d *schema.ResourceData, meta interface{}) error {

--- a/profitbricks/resource_profitbricks_volume_test.go
+++ b/profitbricks/resource_profitbricks_volume_test.go
@@ -24,14 +24,12 @@ func TestAccProfitBricksVolume_Basic(t *testing.T) {
 				Config: fmt.Sprintf(testAccCheckProfitbricksVolumeConfig_basic, volumeName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfitBricksVolumeExists("profitbricks_volume.database_volume", &volume),
-					testAccCheckProfitBricksVolumeAttributes("profitbricks_volume.database_volume", volumeName),
 					resource.TestCheckResourceAttr("profitbricks_volume.database_volume", "name", volumeName),
 				),
 			},
 			resource.TestStep{
 				Config: testAccCheckProfitbricksVolumeConfig_update,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckProfitBricksVolumeAttributes("profitbricks_volume.database_volume", "updated"),
 					resource.TestCheckResourceAttr("profitbricks_volume.database_volume", "name", "updated"),
 				),
 			},

--- a/profitbricks/resource_profitbricks_volume_test.go
+++ b/profitbricks/resource_profitbricks_volume_test.go
@@ -116,7 +116,7 @@ resource "profitbricks_server" "webserver" {
   volume {
     name = "system"
     size = 5
-    disk_type = "SSD"
+    disk_type = "HDD"
     image_name ="ubuntu-16.04"
     image_password = "K3tTj8G14a3EgKyNeeiY"
 }
@@ -136,10 +136,11 @@ resource "profitbricks_server" "webserver" {
 resource "profitbricks_volume" "database_volume" {
   datacenter_id = "${profitbricks_datacenter.foobar.id}"
   server_id = "${profitbricks_server.webserver.id}"
+  availability_zone = "ZONE_1"
   licence_type = "OTHER"
   name = "%s"
   size = 5
-  disk_type = "SSD"
+  disk_type = "HDD"
   bus = "VIRTIO"
 }`
 
@@ -165,7 +166,7 @@ resource "profitbricks_server" "webserver" {
   volume {
     name = "system"
     size = 5
-    disk_type = "SSD"
+    disk_type = "HDD"
     image_name ="ubuntu-16.04"
     image_password = "K3tTj8G14a3EgKyNeeiY"
 }
@@ -186,8 +187,9 @@ resource "profitbricks_volume" "database_volume" {
   datacenter_id = "${profitbricks_datacenter.foobar.id}"
   server_id = "${profitbricks_server.webserver.id}"
   licence_type = "OTHER"
+  availability_zone = "ZONE_1"
   name = "updated"
   size = 5
-  disk_type = "SSD"
+  disk_type = "HDD"
   bus = "VIRTIO"
 }`

--- a/profitbricks/resource_profitbricks_volume_test.go
+++ b/profitbricks/resource_profitbricks_volume_test.go
@@ -20,14 +20,14 @@ func TestAccProfitBricksVolume_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDProfitBricksVolumeDestroyCheck,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckProfitbricksVolumeConfig_basic, volumeName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckProfitBricksVolumeExists("profitbricks_volume.database_volume", &volume),
 					resource.TestCheckResourceAttr("profitbricks_volume.database_volume", "name", volumeName),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckProfitbricksVolumeConfig_update,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("profitbricks_volume.database_volume", "name", "updated"),
@@ -51,20 +51,6 @@ func testAccCheckDProfitBricksVolumeDestroyCheck(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckProfitBricksVolumeAttributes(n string, name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("testAccCheckProfitBricksVolumeAttributes: Not found: %s", n)
-		}
-		if rs.Primary.Attributes["name"] != name {
-			return fmt.Errorf("Bad name: %s", rs.Primary.Attributes["name"])
-		}
-
-		return nil
-	}
 }
 
 func testAccCheckProfitBricksVolumeExists(n string, volume *profitbricks.Volume) resource.TestCheckFunc {


### PR DESCRIPTION
The output looks like this:
```
make testacc TEST=./profitbricks/ 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./profitbricks/ -v  -timeout 120m
=== RUN   TestAccDataSourceDatacenter_matching
--- PASS: TestAccDataSourceDatacenter_matching (12.83s)
=== RUN   TestAccDataSourceImage_basic
--- PASS: TestAccDataSourceImage_basic (1.33s)
=== RUN   TestAccDataSourceLocation_basic
--- PASS: TestAccDataSourceLocation_basic (0.66s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccProfitBricksDataCenter_Basic
--- PASS: TestAccProfitBricksDataCenter_Basic (54.23s)
=== RUN   TestAccProfitBricksFirewall_Basic
--- PASS: TestAccProfitBricksFirewall_Basic (316.28s)
=== RUN   TestAccProfitBricksIPBlock_Basic
--- PASS: TestAccProfitBricksIPBlock_Basic (1.51s)
=== RUN   TestAccProfitBricksLan_Basic
--- PASS: TestAccProfitBricksLan_Basic (45.51s)
=== RUN   TestAccProfitBricksLoadbalancer_Basic
--- FAIL: TestAccProfitBricksLoadbalancer_Basic (297.22s)
        testing.go:428: Step 0 error: After applying this step, the plan was not empty:
                
                DIFF:
                
                UPDATE: profitbricks_loadbalancer.example
                  ip: "10.11.28.225" => ""
                
                STATE:
                
                profitbricks_datacenter.foobar:
                  ID = 9a2138e4-bab5-4842-a15f-2c6eb5f8e35e
                  description = 
                  location = us/las
                  name = loadbalancer-test
                profitbricks_loadbalancer.example:
                  ID = ce6e9dfd-8d10-4e24-a5de-edd727f15cda
                  datacenter_id = 9a2138e4-bab5-4842-a15f-2c6eb5f8e35e
                  dhcp = true
                  ip = 10.11.28.225
                  name = loadbalancer
                  nic_id = 59b30776-2dec-4178-a492-959813060860
                
                  Dependencies:
                    profitbricks_datacenter.foobar
                    profitbricks_nic.database_nic
                profitbricks_nic.database_nic:
                  ID = 59b30776-2dec-4178-a492-959813060860
                  datacenter_id = 9a2138e4-bab5-4842-a15f-2c6eb5f8e35e
                  dhcp = true
                  firewall_active = true
                  ips.# = 1
                  ips.0 = 10.12.82.11
                  lan = 2
                  name = updated
                  server_id = 9176821c-b45f-46d3-bfe8-aea8a5b89814
                
                  Dependencies:
                    profitbricks_datacenter.foobar
                    profitbricks_server.webserver
                profitbricks_server.webserver:
                  ID = 9176821c-b45f-46d3-bfe8-aea8a5b89814
                  availability_zone = ZONE_1
                  boot_volume = 2e0d77d8-055e-47eb-9c3b-4921d1bd15d9
                  cores = 1
                  cpu_family = AMD_OPTERON
                  datacenter_id = 9a2138e4-bab5-4842-a15f-2c6eb5f8e35e
                  name = webserver
                  nic.# = 1
                  nic.4050551175.dhcp = true
                  nic.4050551175.firewall.# = 1
                  nic.4050551175.firewall.4236383148.icmp_code = 
                  nic.4050551175.firewall.4236383148.icmp_type = 
                  nic.4050551175.firewall.4236383148.ip = 
                  nic.4050551175.firewall.4236383148.ips.# = 0
                  nic.4050551175.firewall.4236383148.name = SSH
                  nic.4050551175.firewall.4236383148.port_range_end = 22
                  nic.4050551175.firewall.4236383148.port_range_start = 22
                  nic.4050551175.firewall.4236383148.protocol = TCP
                  nic.4050551175.firewall.4236383148.source_ip = 
                  nic.4050551175.firewall.4236383148.source_mac = 
                  nic.4050551175.firewall.4236383148.target_ip = 
                  nic.4050551175.firewall_active = true
                  nic.4050551175.ip = 
                  nic.4050551175.ips.# = 1
                  nic.4050551175.ips.0 = 10.8.84.11
                  nic.4050551175.lan = 1
                  nic.4050551175.name = 
                  nic.4050551175.nat = false
                  primary_ip = 10.8.84.11
                  primary_nic = a32e38e2-9c6b-40a3-9160-d0c368136658
                  ram = 1024
                  volume.# = 1
                  volume.1751962873.availability_zone = 
                  volume.1751962873.bus = 
                  volume.1751962873.disk_type = SSD
                  volume.1751962873.image_name = ubuntu-16.04
                  volume.1751962873.image_password = K3tTj8G14a3EgKyNeeiY
                  volume.1751962873.licence_type = 
                  volume.1751962873.name = system
                  volume.1751962873.size = 5
                  volume.1751962873.ssh_key_path.# = 0
                
                  Dependencies:
                    profitbricks_datacenter.foobar
=== RUN   TestAccProfitBricksNic_Basic
--- PASS: TestAccProfitBricksNic_Basic (271.21s)
=== RUN   TestAccProfitBricksServer_Basic
--- PASS: TestAccProfitBricksServer_Basic (229.28s)
=== RUN   TestAccProfitBricksVolume_Basic
--- PASS: TestAccProfitBricksVolume_Basic (268.33s)
FAIL
```

The only known issue is with ProfitBricks load balancers. When assigning a server to a load balancer public access to internet is changed and server is assigned to a private LAN whichi is causing the error from above.

I also made `TestAccDataSourceImage_basic` so it doesn't fail every month when Image names are changed.

p.s. @radeksimko Thank you for asistance today