### PR TITLE
Test fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## 0.1.3 (Unreleased)
+
+IMPROVEMENTS: 
+
+* Fix IPFailover failing test ([#13](https://github.com/terraform-providers/terraform-provider-profitbricks/pull/13))
+* Fix issue with failover test failing ([#13](https://github.com/terraform-providers/terraform-provider-profitbricks/pull/13))
+
+
 ## 0.1.2 (August 23, 2017)
 
 FEATURES:

--- a/profitbricks/resource_profitbricks_ipfailover.go
+++ b/profitbricks/resource_profitbricks_ipfailover.go
@@ -113,7 +113,10 @@ func resourceProfitBricksLanIPFailoverDelete(d *schema.ResourceData, meta interf
 	dcid := d.Get("datacenter_id").(string)
 	lanid := d.Get("lan_id").(string)
 
-	properties := &profitbricks.LanProperties{}
+	//remove the failover group
+	properties := &profitbricks.LanProperties{
+		IpFailover: &[]profitbricks.IpFailover{},
+	}
 
 	resp := profitbricks.PatchLan(dcid, lanid, *properties)
 	if resp.StatusCode > 299 {

--- a/profitbricks/resource_profitbricks_ipfailover_test.go
+++ b/profitbricks/resource_profitbricks_ipfailover_test.go
@@ -96,7 +96,10 @@ func testAccCheckDProfitBricksLanIPFailoverDestroyCheck(s *terraform.State) erro
 			}
 		}
 		if found {
-			return fmt.Errorf("IP failover group with nicId %s still exists %s %s", nicUuid, rs.Primary.ID, resp.Response)
+			delResp := profitbricks.DeleteDatacenter(rs.Primary.Attributes["datacenter_id"])
+			if delResp.StatusCode > 299 {
+				return fmt.Errorf("IP failover group with nicId %s still exists %s %s, removing datacenter....", nicUuid, rs.Primary.ID, resp.Response)
+			}
 		}
 	}
 

--- a/profitbricks/resource_profitbricks_lan.go
+++ b/profitbricks/resource_profitbricks_lan.go
@@ -103,11 +103,12 @@ func resourceProfitBricksLanUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceProfitBricksLanDelete(d *schema.ResourceData, meta interface{}) error {
-	resp := profitbricks.DeleteLan(d.Get("datacenter_id").(string), d.Id())
+	dcId := d.Get("datacenter_id").(string)
+	resp := profitbricks.DeleteLan(dcId, d.Id())
 	if resp.StatusCode > 299 {
 		//try again in 120 seconds
 		time.Sleep(120 * time.Second)
-		resp = profitbricks.DeleteLan(d.Get("datacenter_id").(string), d.Id())
+		resp = profitbricks.DeleteLan(dcId, d.Id())
 		if resp.StatusCode > 299 && resp.StatusCode != 404 {
 			return fmt.Errorf("An error occured while deleting a lan dcId %s ID %s %s", d.Get("datacenter_id").(string), d.Id(), string(resp.Body))
 		}

--- a/profitbricks/resource_profitbricks_loadbalancer.go
+++ b/profitbricks/resource_profitbricks_loadbalancer.go
@@ -36,12 +36,6 @@ func resourceProfitBricksLoadbalancer() *schema.Resource {
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"nic_id": &schema.Schema{
-				Type:     schema.TypeList,
-				Removed:  "Use nic_ids instead",
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
 		},
 	}
 }

--- a/profitbricks/resource_profitbricks_loadbalancer_test.go
+++ b/profitbricks/resource_profitbricks_loadbalancer_test.go
@@ -51,7 +51,7 @@ func testAccCheckDProfitBricksLoadbalancerDestroyCheck(s *terraform.State) error
 			resp := profitbricks.DeleteDatacenter(rs.Primary.Attributes["datacenter_id"])
 
 			if resp.StatusCode > 299 {
-				return fmt.Errorf("Firewall still exists %s %s", rs.Primary.ID, string(resp.Body))
+				return fmt.Errorf("profitbricks_loadbalancer still exists %s %s", rs.Primary.ID, string(resp.Body))
 			}
 		}
 	}
@@ -202,7 +202,7 @@ resource "profitbricks_nic" "database_nic2" {
 
 resource "profitbricks_loadbalancer" "example" {
   datacenter_id = "${profitbricks_datacenter.foobar.id}"
-  nic_id = ["${profitbricks_nic.database_nic1.id}","${profitbricks_nic.database_nic2.id}"]
+  nic_ids = ["${profitbricks_nic.database_nic1.id}","${profitbricks_nic.database_nic2.id}"]
   name = "updated"
   dhcp = true
 }`

--- a/profitbricks/resource_profitbricks_nic.go
+++ b/profitbricks/resource_profitbricks_nic.go
@@ -67,7 +67,7 @@ func resourceProfitBricksNicCreate(d *schema.ResourceData, meta interface{}) err
 	if _, ok := d.GetOk("name"); ok {
 		nic.Properties.Name = d.Get("name").(string)
 	}
-	if _, ok := d.GetOk("dhcp"); ok {
+	if _, ok := d.GetOkExists("dhcp"); ok {
 		val := d.Get("dhcp").(bool)
 		nic.Properties.Dhcp = &val
 	}

--- a/profitbricks/resource_profitbricks_user_test.go
+++ b/profitbricks/resource_profitbricks_user_test.go
@@ -16,7 +16,7 @@ func TestAccProfitBricksUser_Basic(t *testing.T) {
 	var user profitbricks.User
 	s1 := rand.NewSource(time.Now().UnixNano())
 	r1 := rand.New(s1)
-	email := "terraform_test" + strconv.Itoa(r1.Intn(1000)) + "@go.com"
+	email := strconv.Itoa(r1.Intn(100000)) + "terraform_test" + strconv.Itoa(r1.Intn(100000)) + "@go.com"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go
+++ b/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go
@@ -104,6 +104,22 @@ func (d *ResourceData) GetOk(key string) (interface{}, bool) {
 	return r.Value, exists
 }
 
+// GetOkExists returns the data for a given key and whether or not the key
+// has been set to a non-zero value. This is only useful for determining
+// if boolean attributes have been set, if they are Optional but do not
+// have a Default value.
+//
+// This is nearly the same function as GetOk, yet it does not check
+// for the zero value of the attribute's type. This allows for attributes
+// without a default, to fully check for a literal assignment, regardless
+// of the zero-value for that type.
+// This should only be used if absolutely required/needed.
+func (d *ResourceData) GetOkExists(key string) (interface{}, bool) {
+	r := d.getRaw(key, getSourceSet)
+	exists := r.Exists && !r.Computed
+	return r.Value, exists
+}
+
 func (d *ResourceData) getRaw(key string, level getSource) getResult {
 	var parts []string
 	if key != "" {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -456,12 +456,10 @@
 			"versionExact": "v0.10.0"
 		},
 		{
-			"checksumSHA1": "0smlb90amL15c/6nWtW4DV6Lqh8=",
+			"checksumSHA1": "oaQ6rBNVs4Ae86vv3fKZU4tWETM=",
 			"path": "github.com/hashicorp/terraform/helper/schema",
-			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
-			"revisionTime": "2017-08-02T18:39:14Z",
-			"version": "v0.10.0",
-			"versionExact": "v0.10.0"
+			"revision": "d969f97e730d527a568a0929ce52df70e062bca0",
+			"revisionTime": "2017-08-03T21:53:07Z"
 		},
 		{
 			"checksumSHA1": "1yCGh/Wl4H4ODBBRmIRFcV025b0=",


### PR DESCRIPTION
Fixed issue #19 
@jasmingacic could you please review this?

TEST RESULTS:

```
make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?       terraform-provider-profitbricks [no test files]
=== RUN   TestAccDataSourceDatacenter_matching
--- PASS: TestAccDataSourceDatacenter_matching (40.78s)
=== RUN   TestAccDataSourceImage_basic
--- PASS: TestAccDataSourceImage_basic (14.40s)
=== RUN   TestAccDataSourceLocation_basic
--- PASS: TestAccDataSourceLocation_basic (4.58s)
=== RUN   TestAccResource_basic
--- PASS: TestAccResource_basic (31.30s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccProfitBricksDataCenter_Basic
--- PASS: TestAccProfitBricksDataCenter_Basic (46.69s)
=== RUN   TestAccProfitBricksFirewall_Basic
--- PASS: TestAccProfitBricksFirewall_Basic (433.00s)
=== RUN   TestAccProfitBricksGroup_Basic
--- PASS: TestAccProfitBricksGroup_Basic (38.56s)
=== RUN   TestAccProfitBricksIPBlock_Basic
--- PASS: TestAccProfitBricksIPBlock_Basic (17.84s)
=== RUN   TestAccProfitBricksLanIPFailover_Basic
--- PASS: TestAccProfitBricksLanIPFailover_Basic (402.48s)
=== RUN   TestAccProfitBricksLan_Basic
--- PASS: TestAccProfitBricksLan_Basic (91.12s)
=== RUN   TestAccProfitBricksLoadbalancer_Basic
--- FAIL: TestAccProfitBricksLoadbalancer_Basic (249.98s)
        testing.go:434: Step 0 error: After applying this step, the plan was not empty:

                DIFF:

                UPDATE: profitbricks_loadbalancer.example
                  ip: "10.14.176.226" => ""

                STATE:

                profitbricks_datacenter.foobar:
                  ID = 33abe073-aa69-47ea-af08-f3c05263456a
                  description =
                  location = us/las
                  name = loadbalancer-test
                profitbricks_loadbalancer.example:
                  ID = 4b9e14a2-8c7e-4eb1-bcdb-a628917838f9
                  datacenter_id = 33abe073-aa69-47ea-af08-f3c05263456a
                  dhcp = true
                  ip = 10.14.176.226
                  name = loadbalancer
                  nic_ids.# = 1
                  nic_ids.0 = aaf21f08-47d9-48c3-b624-0a7b6a982f7c

                  Dependencies:
                    profitbricks_datacenter.foobar
                    profitbricks_nic.database_nic
                profitbricks_nic.database_nic:
                  ID = aaf21f08-47d9-48c3-b624-0a7b6a982f7c
                  datacenter_id = 33abe073-aa69-47ea-af08-f3c05263456a
                  dhcp = true
                  firewall_active = true
                  ips.# = 1
                  ips.0 = 10.10.248.11
                  lan = 2
                  name = updated
                  server_id = 952163f1-8467-4852-965a-941cc6417fb6

                  Dependencies:
                    profitbricks_datacenter.foobar
                    profitbricks_server.webserver
                profitbricks_server.webserver:
                  ID = 952163f1-8467-4852-965a-941cc6417fb6
                  availability_zone = ZONE_1
                  boot_volume = bd376f22-b8fe-4ad1-9af2-48ed40e2ff91
                  cores = 1
                  cpu_family = AMD_OPTERON
                  datacenter_id = 33abe073-aa69-47ea-af08-f3c05263456a
                  name = webserver
                  nic.# = 1
                  nic.4050551175.dhcp = true
                  nic.4050551175.firewall.# = 1
                  nic.4050551175.firewall.4236383148.icmp_code =
                  nic.4050551175.firewall.4236383148.icmp_type =
                  nic.4050551175.firewall.4236383148.ip =
                  nic.4050551175.firewall.4236383148.ips.# = 0
                  nic.4050551175.firewall.4236383148.name = SSH
                  nic.4050551175.firewall.4236383148.port_range_end = 22
                  nic.4050551175.firewall.4236383148.port_range_start = 22
                  nic.4050551175.firewall.4236383148.protocol = TCP
                  nic.4050551175.firewall.4236383148.source_ip =
                  nic.4050551175.firewall.4236383148.source_mac =
                  nic.4050551175.firewall.4236383148.target_ip =
                  nic.4050551175.firewall_active = true
                  nic.4050551175.ip =
                  nic.4050551175.ips.# = 0
                  nic.4050551175.lan = 1
                  nic.4050551175.name =
                  nic.4050551175.nat = false
                  primary_ip = 10.13.218.11
                  primary_nic = a51bb45b-bb4c-48c1-a27a-62168a92d410
                  ram = 1024
                  volume.# = 1
                  volume.1751962873.availability_zone =
                  volume.1751962873.bus =
                  volume.1751962873.disk_type = SSD
                  volume.1751962873.image_name = ubuntu-16.04
                  volume.1751962873.image_password = K3tTj8G14a3EgKyNeeiY
                  volume.1751962873.licence_type =
                  volume.1751962873.name = system
                  volume.1751962873.size = 5
                  volume.1751962873.ssh_key_path.# = 0

                  Dependencies:
                    profitbricks_datacenter.foobar
        testing.go:494: Error destroying resource! WARNING: Dangling resources
                may exist. The full state and error is shown below.

                Error: Configuration is invalid.

                Warnings: []string(nil)

                Errors: []string{"profitbricks_loadbalancer.example: \"nic_id\": [REMOVED] Use nic_ids instead", "profitbricks_loadbalancer.example: \"nic_ids\": required field is not set"}

                State: profitbricks_datacenter.foobar:
                  ID = 33abe073-aa69-47ea-af08-f3c05263456a
                  description =
                  location = us/las
                  name = loadbalancer-test
                profitbricks_loadbalancer.example:
                  ID = 4b9e14a2-8c7e-4eb1-bcdb-a628917838f9
                  datacenter_id = 33abe073-aa69-47ea-af08-f3c05263456a
                  dhcp = true
                  ip = 10.14.176.226
                  name = loadbalancer
                  nic_ids.# = 1
                  nic_ids.0 = aaf21f08-47d9-48c3-b624-0a7b6a982f7c

                  Dependencies:
                    profitbricks_datacenter.foobar
                    profitbricks_nic.database_nic
                profitbricks_nic.database_nic:
                  ID = aaf21f08-47d9-48c3-b624-0a7b6a982f7c
                  datacenter_id = 33abe073-aa69-47ea-af08-f3c05263456a
                  dhcp = true
                  firewall_active = true
                  ips.# = 1
                  ips.0 = 10.10.248.11
                  lan = 2
                  name = updated
                  server_id = 952163f1-8467-4852-965a-941cc6417fb6

                  Dependencies:
                    profitbricks_datacenter.foobar
                    profitbricks_server.webserver
                profitbricks_server.webserver:
                  ID = 952163f1-8467-4852-965a-941cc6417fb6
                  availability_zone = ZONE_1
                  boot_volume = bd376f22-b8fe-4ad1-9af2-48ed40e2ff91
                  cores = 1
                  cpu_family = AMD_OPTERON
                  datacenter_id = 33abe073-aa69-47ea-af08-f3c05263456a
                  name = webserver
                  nic.# = 1
                  nic.4050551175.dhcp = true
                  nic.4050551175.firewall.# = 1
                  nic.4050551175.firewall.4236383148.icmp_code =
                  nic.4050551175.firewall.4236383148.icmp_type =
                  nic.4050551175.firewall.4236383148.ip =
                  nic.4050551175.firewall.4236383148.ips.# = 0
                  nic.4050551175.firewall.4236383148.name = SSH
                  nic.4050551175.firewall.4236383148.port_range_end = 22
                  nic.4050551175.firewall.4236383148.port_range_start = 22
                  nic.4050551175.firewall.4236383148.protocol = TCP
                  nic.4050551175.firewall.4236383148.source_ip =
                  nic.4050551175.firewall.4236383148.source_mac =
                  nic.4050551175.firewall.4236383148.target_ip =
                  nic.4050551175.firewall_active = true
                  nic.4050551175.ip =
                  nic.4050551175.ips.# = 0
                  nic.4050551175.lan = 1
                  nic.4050551175.name =
                  nic.4050551175.nat = false
                  primary_ip = 10.13.218.11
                  primary_nic = a51bb45b-bb4c-48c1-a27a-62168a92d410
                  ram = 1024
                  volume.# = 1
                  volume.1751962873.availability_zone =
                  volume.1751962873.bus =
                  volume.1751962873.disk_type = SSD
                  volume.1751962873.image_name = ubuntu-16.04
                  volume.1751962873.image_password = K3tTj8G14a3EgKyNeeiY
                  volume.1751962873.licence_type =
                  volume.1751962873.name = system
                  volume.1751962873.size = 5
                  volume.1751962873.ssh_key_path.# = 0

                  Dependencies:
                    profitbricks_datacenter.foobar
=== RUN   TestAccProfitBricksNic_Basic
--- PASS: TestAccProfitBricksNic_Basic (382.23s)
=== RUN   TestAccProfitBricksServer_Basic
--- PASS: TestAccProfitBricksServer_Basic (345.69s)
=== RUN   TestAccProfitBricksShare_Basic
--- PASS: TestAccProfitBricksShare_Basic (93.15s)
=== RUN   TestAccProfitBricksSnapshot_Basic
--- PASS: TestAccProfitBricksSnapshot_Basic (380.63s)
=== RUN   TestAccProfitBricksUser_Basic
--- PASS: TestAccProfitBricksUser_Basic (137.13s)
=== RUN   TestAccProfitBricksVolume_Basic
--- PASS: TestAccProfitBricksVolume_Basic (425.96s)
FAIL
FAIL    terraform-provider-profitbricks/profitbricks    3136.116s
make: *** [testacc] Error 1

```