### PR TITLE
Set cpu_family to computed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 1.5.0 (Unreleased)
+
+## 1.4.4 (Unreleased)
+
+BUG FIXES:
+- Set cpu_family to computed. ([#54](https://github.com/terraform-providers/terraform-provider-profitbricks/pull/54))
+
 ## 1.4.3 (March 14, 2019)
 
 BUG FIXES:

--- a/profitbricks/resource_profitbricks_server.go
+++ b/profitbricks/resource_profitbricks_server.go
@@ -57,6 +57,7 @@ func resourceProfitBricksServer() *schema.Resource {
 			"cpu_family": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"boot_image": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Setting no value for cpu family will use the location's default,
but would trigger an unrequired change on plans later on.