### PR TITLE
Persist resource ids in state before syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 1.5.0 (Unreleased)
+## 1.4.5 (Unreleased)
+
+BUG FIXES:
+- Persist resource ids in state before syncing ([#57]https://github.com/terraform-providers/terraform-provider-profitbricks/pull/57)
+
 ## 1.4.4 (April 04, 2019)
 
 BUG FIXES:

--- a/profitbricks/data_source_datacenter.go
+++ b/profitbricks/data_source_datacenter.go
@@ -2,10 +2,11 @@ package profitbricks
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/profitbricks/profitbricks-sdk-go"
 	"log"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/profitbricks/profitbricks-sdk-go"
 )
 
 func dataSourceDataCenter() *schema.Resource {

--- a/profitbricks/data_source_image.go
+++ b/profitbricks/data_source_image.go
@@ -2,9 +2,10 @@ package profitbricks
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/profitbricks/profitbricks-sdk-go"
-	"strings"
 )
 
 func dataSourceImage() *schema.Resource {

--- a/profitbricks/data_source_image_test.go
+++ b/profitbricks/data_source_image_test.go
@@ -1,9 +1,10 @@
 package profitbricks
 
 import (
-	"github.com/hashicorp/terraform/helper/resource"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccDataSourceImage_basic(t *testing.T) {

--- a/profitbricks/data_source_location.go
+++ b/profitbricks/data_source_location.go
@@ -2,10 +2,11 @@ package profitbricks
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/profitbricks/profitbricks-sdk-go"
 	"log"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/profitbricks/profitbricks-sdk-go"
 )
 
 func dataSourceLocation() *schema.Resource {

--- a/profitbricks/data_source_location_test.go
+++ b/profitbricks/data_source_location_test.go
@@ -1,8 +1,9 @@
 package profitbricks
 
 import (
-	"github.com/hashicorp/terraform/helper/resource"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccDataSourceLocation_basic(t *testing.T) {

--- a/profitbricks/data_source_resource.go
+++ b/profitbricks/data_source_resource.go
@@ -2,6 +2,7 @@ package profitbricks
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/profitbricks/profitbricks-sdk-go"
 )

--- a/profitbricks/data_source_resource_test.go
+++ b/profitbricks/data_source_resource_test.go
@@ -1,8 +1,9 @@
 package profitbricks
 
 import (
-	"github.com/hashicorp/terraform/helper/resource"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccResource_basic(t *testing.T) {

--- a/profitbricks/data_source_snapshot.go
+++ b/profitbricks/data_source_snapshot.go
@@ -2,9 +2,10 @@ package profitbricks
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/profitbricks/profitbricks-sdk-go"
-	"strings"
 )
 
 func dataSourceSnapshot() *schema.Resource {

--- a/profitbricks/import_profitbricks_datacenter_test.go
+++ b/profitbricks/import_profitbricks_datacenter_test.go
@@ -2,8 +2,9 @@ package profitbricks
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/resource"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccProfitBricksDataCenter_ImportBasic(t *testing.T) {

--- a/profitbricks/import_profitbricks_firewall_test.go
+++ b/profitbricks/import_profitbricks_firewall_test.go
@@ -3,9 +3,10 @@ package profitbricks
 import (
 	"fmt"
 
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"testing"
 )
 
 func TestAccProfitBricksFirewall_ImportBasic(t *testing.T) {

--- a/profitbricks/import_profitbricks_ipblock_test.go
+++ b/profitbricks/import_profitbricks_ipblock_test.go
@@ -3,8 +3,9 @@ package profitbricks
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform/helper/resource"
 	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccProfitBricksIPBlock_ImportBasic(t *testing.T) {

--- a/profitbricks/import_profitbricks_lan_test.go
+++ b/profitbricks/import_profitbricks_lan_test.go
@@ -3,9 +3,10 @@ package profitbricks
 import (
 	"fmt"
 
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"testing"
 )
 
 func TestAccProfitBricksLan_ImportBasic(t *testing.T) {

--- a/profitbricks/import_profitbricks_nic_test.go
+++ b/profitbricks/import_profitbricks_nic_test.go
@@ -3,9 +3,10 @@ package profitbricks
 import (
 	"fmt"
 
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"testing"
 )
 
 func TestAccProfitBricksNic_ImportBasic(t *testing.T) {

--- a/profitbricks/import_profitbricks_server_test.go
+++ b/profitbricks/import_profitbricks_server_test.go
@@ -3,9 +3,10 @@ package profitbricks
 import (
 	"fmt"
 
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"testing"
 )
 
 func TestAccProfitBricksServer_ImportBasic(t *testing.T) {

--- a/profitbricks/provider.go
+++ b/profitbricks/provider.go
@@ -131,6 +131,19 @@ func getStateChangeConf(meta interface{}, d *schema.ResourceData, location strin
 	return stateConf
 }
 
+type RequestFailedError struct {
+	msg string
+}
+
+func (e RequestFailedError) Error() string {
+	return e.msg
+}
+
+func IsRequestFailed(err error) bool {
+	_, ok := err.(RequestFailedError)
+	return ok
+}
+
 // resourceStateRefreshFunc tracks progress of a request
 func resourceStateRefreshFunc(meta interface{}, path string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
@@ -147,7 +160,7 @@ func resourceStateRefreshFunc(meta interface{}, path string) resource.StateRefre
 		}
 
 		if request.Metadata.Status == "FAILED" {
-			return nil, "", fmt.Errorf("Request failed with following error: %s", request.Metadata.Message)
+			return nil, "", RequestFailedError{fmt.Sprintf("Request failed with following error: %s", request.Metadata.Message)}
 		}
 
 		if request.Metadata.Status == "DONE" {

--- a/profitbricks/resource_profitbricks_datacenter.go
+++ b/profitbricks/resource_profitbricks_datacenter.go
@@ -67,6 +67,10 @@ func resourceProfitBricksDatacenterCreate(d *schema.ResourceData, meta interface
 	// Wait, catching any errors
 	_, errState := getStateChangeConf(meta, d, dc.Headers.Get("Location"), schema.TimeoutCreate).WaitForState()
 	if errState != nil {
+		if IsRequestFailed(err) {
+			// Request failed, so resource was not created, delete resource from state file
+			d.SetId("")
+		}
 		return errState
 	}
 

--- a/profitbricks/resource_profitbricks_firewall.go
+++ b/profitbricks/resource_profitbricks_firewall.go
@@ -141,14 +141,17 @@ func resourceProfitBricksFirewallCreate(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return fmt.Errorf("An error occured while creating a firewall rule: %s", err)
 	}
+	d.SetId(fw.ID)
 
 	// Wait, catching any errors
 	_, errState := getStateChangeConf(meta, d, fw.Headers.Get("Location"), schema.TimeoutCreate).WaitForState()
 	if errState != nil {
+		if IsRequestFailed(err) {
+			// Request failed, so resource was not created, delete resource from state file
+			d.SetId("")
+		}
 		return errState
 	}
-
-	d.SetId(fw.ID)
 
 	return resourceProfitBricksFirewallRead(d, meta)
 }

--- a/profitbricks/resource_profitbricks_group.go
+++ b/profitbricks/resource_profitbricks_group.go
@@ -107,14 +107,17 @@ func resourceProfitBricksGroupCreate(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return fmt.Errorf("An error occured while creating a group: %s", err)
 	}
+	d.SetId(group.ID)
 
 	// Wait, catching any errors
 	_, errState := getStateChangeConf(meta, d, group.Headers.Get("Location"), schema.TimeoutCreate).WaitForState()
 	if errState != nil {
+		if IsRequestFailed(err) {
+			// Request failed, so resource was not created, delete resource from state file
+			d.SetId("")
+		}
 		return errState
 	}
-
-	d.SetId(group.ID)
 
 	//add users to group if any is provided
 	if usertoAdd != "" {

--- a/profitbricks/resource_profitbricks_ipblock.go
+++ b/profitbricks/resource_profitbricks_ipblock.go
@@ -59,14 +59,17 @@ func resourceProfitBricksIPBlockCreate(d *schema.ResourceData, meta interface{})
 	if err != nil {
 		return fmt.Errorf("An error occured while reserving an ip block: %s", err)
 	}
+	d.SetId(ipblock.ID)
 
 	// Wait, catching any errors
 	_, errState := getStateChangeConf(meta, d, ipblock.Headers.Get("Location"), schema.TimeoutCreate).WaitForState()
 	if errState != nil {
+		if IsRequestFailed(err) {
+			// Request failed, so resource was not created, delete resource from state file
+			d.SetId("")
+		}
 		return errState
 	}
-
-	d.SetId(ipblock.ID)
 
 	return resourceProfitBricksIPBlockRead(d, meta)
 }

--- a/profitbricks/resource_profitbricks_lan.go
+++ b/profitbricks/resource_profitbricks_lan.go
@@ -61,13 +61,17 @@ func resourceProfitBricksLanCreate(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("An error occured while creating a lan: %s", err)
 	}
 
+	d.SetId(lan.ID)
 	// Wait, catching any errors
 	_, errState := getStateChangeConf(meta, d, lan.Headers.Get("Location"), schema.TimeoutCreate).WaitForState()
 	if errState != nil {
+		if IsRequestFailed(err) {
+			// Request failed, so resource was not created, delete resource from state file
+			d.SetId("")
+		}
 		return errState
 	}
 
-	d.SetId(lan.ID)
 	return resourceProfitBricksLanRead(d, meta)
 }
 

--- a/profitbricks/resource_profitbricks_loadbalancer.go
+++ b/profitbricks/resource_profitbricks_loadbalancer.go
@@ -69,14 +69,17 @@ func resourceProfitBricksLoadbalancerCreate(d *schema.ResourceData, meta interfa
 	if err != nil {
 		return fmt.Errorf("Error occured while creating a loadbalancer %s", err)
 	}
+	d.SetId(lb.ID)
 
 	// Wait, catching any errors
 	_, errState := getStateChangeConf(meta, d, lb.Headers.Get("Location"), schema.TimeoutCreate).WaitForState()
 	if errState != nil {
+		if IsRequestFailed(err) {
+			// Request failed, so resource was not created, delete resource from state file
+			d.SetId("")
+		}
 		return errState
 	}
-
-	d.SetId(lb.ID)
 
 	return resourceProfitBricksLoadbalancerRead(d, meta)
 }

--- a/profitbricks/resource_profitbricks_nic.go
+++ b/profitbricks/resource_profitbricks_nic.go
@@ -98,14 +98,16 @@ func resourceProfitBricksNicCreate(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return fmt.Errorf("Error occured while creating a nic: %s", err)
 	}
-
+	d.SetId(nic.ID)
 	// Wait, catching any errors
 	_, errState := getStateChangeConf(meta, d, nic.Headers.Get("Location"), schema.TimeoutCreate).WaitForState()
 	if errState != nil {
+		if IsRequestFailed(err) {
+			// Request failed, so resource was not created, delete resource from state file
+			d.SetId("")
+		}
 		return errState
 	}
-
-	d.SetId(nic.ID)
 	return resourceProfitBricksNicRead(d, meta)
 }
 

--- a/profitbricks/resource_profitbricks_share.go
+++ b/profitbricks/resource_profitbricks_share.go
@@ -58,14 +58,18 @@ func resourceProfitBricksShareCreate(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return fmt.Errorf("An error occured while creating a share: %s", err)
 	}
+	d.SetId(share.ID)
 
 	// Wait, catching any errors
 	_, errState := getStateChangeConf(meta, d, share.Headers.Get("Location"), schema.TimeoutCreate).WaitForState()
 	if errState != nil {
+		if IsRequestFailed(err) {
+			// Request failed, so resource was not created, delete resource from state file
+			d.SetId("")
+		}
 		return errState
 	}
 
-	d.SetId(share.ID)
 	return resourceProfitBricksShareRead(d, meta)
 }
 

--- a/profitbricks/resource_profitbricks_snapshot.go
+++ b/profitbricks/resource_profitbricks_snapshot.go
@@ -47,13 +47,16 @@ func resourceProfitBricksSnapshotCreate(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("An error occured while creating a snapshot: %s", err)
 	}
 
+	d.SetId(snapshot.ID)
 	// Wait, catching any errors
 	_, errState := getStateChangeConf(meta, d, snapshot.Headers.Get("Location"), schema.TimeoutCreate).WaitForState()
 	if errState != nil {
+		if IsRequestFailed(err) {
+			// Request failed, so resource was not created, delete resource from state file
+			d.SetId("")
+		}
 		return errState
 	}
-
-	d.SetId(snapshot.ID)
 
 	return resourceProfitBricksSnapshotRead(d, meta)
 }

--- a/profitbricks/resource_profitbricks_snapshot_test.go
+++ b/profitbricks/resource_profitbricks_snapshot_test.go
@@ -2,10 +2,11 @@ package profitbricks
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/profitbricks/profitbricks-sdk-go"
-	"testing"
 )
 
 func TestAccProfitBricksSnapshot_Basic(t *testing.T) {

--- a/profitbricks/resource_profitbricks_user.go
+++ b/profitbricks/resource_profitbricks_user.go
@@ -77,13 +77,17 @@ func resourceProfitBricksUserCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("An error occured while creating a user: %s", err)
 	}
 
+	d.SetId(user.ID)
+
 	// Wait, catching any errors
 	_, errState := getStateChangeConf(meta, d, user.Headers.Get("Location"), schema.TimeoutCreate).WaitForState()
 	if errState != nil {
+		if IsRequestFailed(err) {
+			// Request failed, so resource was not created, delete resource from state file
+			d.SetId("")
+		}
 		return errState
 	}
-
-	d.SetId(user.ID)
 	return resourceProfitBricksUserRead(d, meta)
 }
 

--- a/profitbricks/resource_profitbricks_user_test.go
+++ b/profitbricks/resource_profitbricks_user_test.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
-	"github.com/profitbricks/profitbricks-sdk-go"
 	"math/rand"
 	"strconv"
 	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/profitbricks/profitbricks-sdk-go"
 )
 
 func TestAccProfitBricksUser_Basic(t *testing.T) {


### PR DESCRIPTION
When creating a resource, the state was updated immediately afterwards. This could fail for several reasons, e.g. IO errors. This led to state information loss, since the id of a resource
was not persisted beforehand. With this patch all resource ids are persisted upon creation and only deleted if the request failed. 